### PR TITLE
1.2.0: if a woodcutter is swinging, but missing, the damage gets deal…

### DIFF
--- a/ChebsMercenaries/BasePlugin.cs
+++ b/ChebsMercenaries/BasePlugin.cs
@@ -24,11 +24,11 @@ namespace ChebsMercenaries
     {
         public const string PluginGuid = "com.chebgonaz.chebsmercenaries";
         public const string PluginName = "ChebsMercenaries";
-        public const string PluginVersion = "1.1.1";
+        public const string PluginVersion = "1.2.0";
         private const string ConfigFileName =  PluginGuid + ".cfg";
         private static readonly string ConfigFileFullPath = Path.Combine(Paths.ConfigPath, ConfigFileName);
 
-        public readonly System.Version ChebsValheimLibraryVersion = new("1.1.3");
+        public readonly System.Version ChebsValheimLibraryVersion = new("1.2.0");
 
         private readonly Harmony harmony = new(PluginGuid);
         
@@ -106,8 +106,6 @@ namespace ChebsMercenaries
                 
                 HumanMinerMinion.SyncInternalsWithConfigs();
                 HumanWoodcutterMinion.SyncInternalsWithConfigs();
-                SkeletonPickaxe.SyncInternalsWithConfigs(HumanMinerMinion.ToolTier.Value);
-                SkeletonWoodAxe.SyncInternalsWithConfigs(HumanWoodcutterMinion.ToolTier.Value);
                 MercenaryChest.ParseMercCosts();
                 MercenaryChest.UpdateRecipe();
             }
@@ -132,9 +130,7 @@ namespace ChebsMercenaries
             
             HumanMinerMinion.SyncInternalsWithConfigs();
             HumanWoodcutterMinion.SyncInternalsWithConfigs();
-            SkeletonPickaxe.SyncInternalsWithConfigs(HumanMinerMinion.ToolTier.Value);
-            SkeletonWoodAxe.SyncInternalsWithConfigs(HumanWoodcutterMinion.ToolTier.Value);
-            
+
             SetupWatcher();
         }
         

--- a/ChebsMercenaries/Minions/HumanMinerMinion.cs
+++ b/ChebsMercenaries/Minions/HumanMinerMinion.cs
@@ -7,7 +7,6 @@ namespace ChebsNecromancy.Minions
 {
     public class HumanMinerMinion : HumanMinion
     {
-        public static ConfigEntry<int> ToolTier;
         public static ConfigEntry<float> UpdateDelay, LookRadius, RoamRange;
         public static ConfigEntry<string> RockInternalIDsList;
 
@@ -15,9 +14,6 @@ namespace ChebsNecromancy.Minions
 
         public new static void CreateConfigs(BaseUnityPlugin plugin)
         {
-            ToolTier = plugin.Config.Bind("HumanMiner (Server Synced)", "ToolTier",
-                3, new ConfigDescription("The tier of the skeleton's tool: 0 (deerbone), 1 (bronze), 2 (iron), 3 (black metal).", null,
-                    new ConfigurationManagerAttributes { IsAdminOnly = true }));
             UpdateDelay = plugin.Config.Bind("HumanMiner (Server Synced)", "UpdateDelay",
                 6f, new ConfigDescription("The delay, in seconds, between rock/ore searching attempts. Attention: small values may impact performance.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));

--- a/ChebsMercenaries/Minions/HumanWoodcutterMinion.cs
+++ b/ChebsMercenaries/Minions/HumanWoodcutterMinion.cs
@@ -6,14 +6,10 @@ namespace ChebsMercenaries.Minions
 {
     public class HumanWoodcutterMinion : HumanMinion
     {
-        public static ConfigEntry<int> ToolTier;
         public static ConfigEntry<float> UpdateDelay, LookRadius, RoamRange;
 
         public new static void CreateConfigs(BaseUnityPlugin plugin)
         {
-            ToolTier = plugin.Config.Bind("HumanWoodcutter (Server Synced)", "ToolTier",
-                3, new ConfigDescription("The tier of the skeleton's tool: 0 (stone), 1 (flint), 2 (bronze), 3 (iron) or 4 (black metal).", null,
-                    new ConfigurationManagerAttributes { IsAdminOnly = true }));
             UpdateDelay = plugin.Config.Bind("HumanWoodcutter (Server Synced)", "UpdateDelay",
                 6f, new ConfigDescription("The delay, in seconds, between wood searching attempts. Attention: small values may impact performance.", null,
                     new ConfigurationManagerAttributes { IsAdminOnly = true }));

--- a/ChebsMercenaries/Package/manifest.json
+++ b/ChebsMercenaries/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsMercenaries",
   "description": "Cheb's Mercenaries adds mercenaries to Valheim that you can purchase with gold and upgrade with materials to fight (warriors, archers) or perform work (lumberjacks, miners).",
-  "version_number": "1.1.1",
+  "version_number": "1.2.0",
   "website_url": "https://github.com/jpw1991/chebs-mercenaries",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.0"


### PR DESCRIPTION
…t anyway; remove tooltier stuff for simplicity and streamlining. People can use 3rd party item-alteration mods instead